### PR TITLE
Add binary guards to prevent malformed JSON in OpenAPI generation

### DIFF
--- a/src/erldantic_openapi.erl
+++ b/src/erldantic_openapi.erl
@@ -104,7 +104,7 @@ with_request_body(Endpoint, Module, Schema)
     when is_map(Endpoint) andalso is_atom(Module) ->
     Endpoint#{request_body => #{schema => Schema, module => Module}}.
 
--doc("Adds a parameter specification to an endpoint.\nThis function adds a parameter (path, query, header, or cookie) to the endpoint.\nMultiple parameters can be added by calling this function multiple times.\n\n### Parameter Specification\nThe parameter spec should be a map with these keys:\n- name: Parameter name (string)\n- in: Parameter location (path | query | header | cookie)\n- required: Whether the parameter is required (boolean)\n- schema: Schema reference or direct type (erldantic:ed_type_or_ref())\n\n### Returns\nUpdated endpoint map with the new parameter added").
+-doc("Adds a parameter specification to an endpoint.\nThis function adds a parameter (path, query, header, or cookie) to the endpoint.\nMultiple parameters can be added by calling this function multiple times.\n\n### Parameter Specification\nThe parameter spec should be a map with these keys:\n- name: Parameter name (binary)\n- in: Parameter location (path | query | header | cookie)\n- required: Whether the parameter is required (boolean)\n- schema: Schema reference or direct type (erldantic:ed_type_or_ref())\n\n### Returns\nUpdated endpoint map with the new parameter added").
 -doc(#{params =>
            #{"Endpoint" => "Endpoint map to add the parameter to",
              "ParameterSpec" => "Parameter specification map"}}).
@@ -113,8 +113,11 @@ with_request_body(Endpoint, Module, Schema)
                      Module :: module(),
                      ParameterSpec :: parameter_spec()) ->
                         endpoint_spec().
-with_parameter(Endpoint, Module, ParameterSpec)
-    when is_map(Endpoint) andalso is_atom(Module) andalso is_map(ParameterSpec) ->
+with_parameter(Endpoint, Module, #{name := Name} = ParameterSpec)
+    when is_map(Endpoint)
+         andalso is_atom(Module)
+         andalso is_map(ParameterSpec)
+         andalso is_binary(Name) ->
     Parameters = maps:get(parameters, Endpoint, []),
     ParameterWithModule = ParameterSpec#{module => Module},
     Endpoint#{parameters => [ParameterWithModule | Parameters]}.
@@ -226,7 +229,8 @@ generate_operation(Endpoint) ->
 -spec generate_response(response_spec()) -> openapi_response().
 generate_response(#{description := Description,
                     schema := Schema,
-                    module := Module}) ->
+                    module := Module})
+    when is_binary(Description) ->
     ModuleTypeInfo = erldantic_abstract_code:types_in_module(Module),
 
     SchemaContent =
@@ -268,7 +272,8 @@ generate_parameter(#{name := Name,
                      in := In,
                      schema := Schema,
                      module := Module} =
-                       ParameterSpec) ->
+                       ParameterSpec)
+    when is_binary(Name) ->
     ModuleTypeInfo = erldantic_abstract_code:types_in_module(Module),
     Required = maps:get(required, ParameterSpec, false),
 

--- a/test/openapi_endpoint_test.erl
+++ b/test/openapi_endpoint_test.erl
@@ -90,7 +90,7 @@ endpoint_with_request_body_test() ->
 endpoint_with_path_parameter_test() ->
     %% Create endpoint with path parameter
     PathParam =
-        #{name => "id",
+        #{name => <<"id">>,
           in => path,
           required => true,
           schema => {type, user_id, 0}},
@@ -99,7 +99,7 @@ endpoint_with_path_parameter_test() ->
 
     %% Should have the parameter
     ?assertMatch(#{parameters :=
-                       [#{name := "id",
+                       [#{name := <<"id">>,
                           in := path,
                           required := true,
                           schema := {type, user_id, 0}}]},
@@ -109,7 +109,7 @@ endpoint_with_path_parameter_test() ->
 endpoint_with_query_parameter_test() ->
     %% Create endpoint with query parameter
     QueryParam =
-        #{name => "limit",
+        #{name => <<"limit">>,
           in => query,
           required => false,
           schema => #ed_simple_type{type = integer}},
@@ -118,7 +118,7 @@ endpoint_with_query_parameter_test() ->
 
     %% Should have the parameter
     ?assertMatch(#{parameters :=
-                       [#{name := "limit",
+                       [#{name := <<"limit">>,
                           in := query,
                           required := false,
                           schema := #ed_simple_type{type = integer}}]},
@@ -166,7 +166,7 @@ multiple_endpoints_to_openapi_test() ->
                                         {record, user}),
 
     PathParam =
-        #{name => "id",
+        #{name => <<"id">>,
           in => path,
           required => true,
           schema => {type, user_id, 0}},
@@ -264,7 +264,7 @@ endpoint_with_mixed_types_test() ->
     TypeRef = {type, user, 0},
 
     QueryParam =
-        #{name => "filter",
+        #{name => <<"filter">>,
           in => query,
           required => false,
           schema => DirectStringType},

--- a/test/openapi_json_test.erl
+++ b/test/openapi_json_test.erl
@@ -248,7 +248,7 @@ final_json_output_test() ->
     GetUserByIdEndpoint2 =
         erldantic_openapi:with_parameter(GetUserByIdEndpoint1,
                                          ?MODULE,
-                                         #{name => "id",
+                                         #{name => <<"id">>,
                                            in => path,
                                            required => true,
                                            schema => #ed_simple_type{type = integer}}),


### PR DESCRIPTION
## Summary
- Fixes issue where passing `string()` types instead of `binary()` would generate malformed JSON with ASCII arrays
- Adds `is_binary()` guards to prevent weird JSON generation in OpenAPI output
- Updates tests and documentation for consistency

## Changes Made
- Add `is_binary(Name)` guard to `generate_parameter/1` to prevent string parameter names from being encoded as ASCII arrays
- Add `is_binary(Description)` guard to `generate_response/1` for consistency  
- Add `is_binary(Name)` guard to `with_parameter/3` to catch invalid parameter specs early
- Fix documentation to specify "Parameter name (binary)" instead of "(string)"
- Update tests to use binary parameter names (`<<"id">>`) instead of string (`"id"`)

## Problem Solved
**Before**: Passing `string()` where `binary()` was expected would generate malformed JSON like:
```json
"name":[85,115,101,114,45,65,103,101,110,116]
```

**After**: Clean function clause errors prevent malformed JSON, ensuring proper output like:
```json
"name":"User-Agent"
```

## Test Plan
- [x] All existing tests pass
- [x] Guards prevent malformed JSON generation
- [x] Function clause errors provide clear feedback when wrong types are used
- [x] Generated OpenAPI JSON is valid and clean

🤖 Generated with [Claude Code](https://claude.ai/code)